### PR TITLE
Fixes Issue #83, #85 and #87

### DIFF
--- a/02-build-a-simple-spring-boot-microservice/README.md
+++ b/02-build-a-simple-spring-boot-microservice/README.md
@@ -14,6 +14,8 @@ To create our microservice, we will use [https://start.spring.io/](https://start
 
 >💡 __Note:__ All subsequent commands in this workshop should be run from the same directory, except where otherwise indicated via `cd` commands.
 
+In an __empty__ directory execute the curl command line below:
+
 ```bash
 curl https://start.spring.io/starter.tgz -d dependencies=web -d baseDir=simple-microservice -d bootVersion=2.3.8 -d javaVersion=1.8 | tar -xzvf -
 ```
@@ -22,7 +24,9 @@ curl https://start.spring.io/starter.tgz -d dependencies=web -d baseDir=simple-m
 
 ## Add a new Spring MVC Controller
 
-Expanding the newly created "simple-microservice" directory, create a new class called `HelloController` in `src/main/java/com/example/demo`, next to `DemoApplication` with the following content:
+In the `simple-microservice/src/main/java/com/example/demo` directory, create a
+new file  called `HelloController.java` next to `DemoApplication.java` file with
+the following content:
 
 ```java
 package com.example.demo;

--- a/06-build-a-reactive-spring-boot-microservice-using-cosmosdb/README.md
+++ b/06-build-a-reactive-spring-boot-microservice-using-cosmosdb/README.md
@@ -74,9 +74,10 @@ class City {
 }
 ```
 
-Then, in the same location, create a new `CityController` class that will be used to query the database.
+Then, in the same location, create a new `CityController.java` file that
+contains the code that will be used to query the database.
 
-> This class will get its Cosmos DB configuration from the Azure Spring Cloud service binding that we will configure later.
+> The CityController class will get its Cosmos DB configuration from the Azure Spring Cloud service binding that we will configure later.
 
 ```java
 package com.example.demo;


### PR DESCRIPTION
Step 2 - explain that the Java class file should be named as *.java

Step 2 - specify that developers need an empty project directory before executing curl command as the project structure is generated by the curl command

Step 2 - clearly point out that the Spring MVC controller should be put into the src/main/java/xxxx directory