### PR TITLE
Update Spring Boot Version and Adjust Dependencies

### DIFF
--- a/02-build-a-simple-spring-boot-microservice/README.md
+++ b/02-build-a-simple-spring-boot-microservice/README.md
@@ -17,10 +17,10 @@ A typical way to create Spring Boot applications is to use the Spring Initializr
 In an __empty__ directory execute the curl command line below:
 
 ```bash
-curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=web -d baseDir=simple-microservice -d bootVersion=3.1.3 -d javaVersion=17 | tar -xzvf -
+curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=web -d baseDir=simple-microservice -d bootVersion=3.3.2 -d javaVersion=17 | tar -xzvf -
 ```
 
-> We force the Spring Boot version to be 3.1.3, and keep default settings that use the `com.example.demo` package.
+> We force the Spring Boot version to be 3.3.2, and keep default settings that use the `com.example.demo` package.
 
 ## Add a new Spring MVC Controller
 
@@ -130,7 +130,7 @@ If you need to check your code, the final project is available in the ["simple-m
 Here is the final script to build and deploy everything that was done in this guide:
 
 ```
-curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=web -d baseDir=simple-microservice -d bootVersion=3.1.3 -d javaVersion=17 | tar -xzvf -
+curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=web -d baseDir=simple-microservice -d bootVersion=3.3.2 -d javaVersion=17 | tar -xzvf -
 cd simple-microservice
 cat > HelloController.java << EOF
 package com.example.demo;

--- a/02-build-a-simple-spring-boot-microservice/simple-microservice/pom.xml
+++ b/02-build-a-simple-spring-boot-microservice/simple-microservice/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/05-build-a-spring-boot-microservice-using-spring-cloud-features/README.md
+++ b/05-build-a-spring-boot-microservice-using-spring-cloud-features/README.md
@@ -23,7 +23,7 @@ The microservice that we create in this guide is [available here](spring-cloud-m
 To create our microservice, we will invoke the Spring Initalizer service from the command line:
 
 ```bash
-curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=web,cloud-eureka,cloud-config-client -d baseDir=spring-cloud-microservice -d bootVersion=3.1.3 -d javaVersion=17 | tar -xzvf -
+curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=web,cloud-eureka,cloud-config-client -d baseDir=spring-cloud-microservice -d bootVersion=3.3.2 -d javaVersion=17 | tar -xzvf -
 ```
 
 > This time, we add the `Eureka Discovery Client` and the `Config Client` Spring Boot starters, which will respectively automatically trigger the use of Spring Cloud Service Registry and the Spring Cloud Config Server.

--- a/05-build-a-spring-boot-microservice-using-spring-cloud-features/spring-cloud-microservice/pom.xml
+++ b/05-build-a-spring-boot-microservice-using-spring-cloud-features/spring-cloud-microservice/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/06-build-a-reactive-spring-boot-microservice-using-cosmosdb/README.md
+++ b/06-build-a-reactive-spring-boot-microservice-using-cosmosdb/README.md
@@ -38,7 +38,7 @@ The microservice that we create in this guide is [available here](city-service/)
 To create our microservice, we will invoke the Spring Initalizr service from the command line:
 
 ```bash
-curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=webflux,cloud-eureka,cloud-config-client -d baseDir=city-service -d bootVersion=3.1.3 -d javaVersion=17 | tar -xzvf -
+curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=webflux,cloud-eureka,cloud-config-client -d baseDir=city-service -d bootVersion=3.3.2 -d javaVersion=17 | tar -xzvf -
 ```
 
 > We use the `Spring WebFlux`, `Eureka Discovery Client` and the `Config Client` Spring Boot starters.

--- a/06-build-a-reactive-spring-boot-microservice-using-cosmosdb/city-service/pom.xml
+++ b/06-build-a-reactive-spring-boot-microservice-using-cosmosdb/city-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/07-build-a-spring-boot-microservice-using-mysql/README.md
+++ b/07-build-a-spring-boot-microservice-using-mysql/README.md
@@ -107,7 +107,7 @@ Now that we've provisioned the Azure Spring Apps instance and configured the Ser
 To create our microservice, we will invoke the Spring Initalizr service from the command line:
 
 ```bash
-curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=web,data-jpa,mysql,cloud-eureka,cloud-config-client -d baseDir=weather-service -d bootVersion=3.1.3 -d javaVersion=17 | tar -xzvf -
+curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=web,data-jpa,mysql,cloud-eureka,cloud-config-client -d baseDir=weather-service -d bootVersion=3.3.2 -d javaVersion=17 | tar -xzvf -
 ```
 
 > We use the `Spring Web`, `Spring Data JPA`, `MySQL Driver`, `Eureka Discovery Client` and the `Config Client` components.

--- a/07-build-a-spring-boot-microservice-using-mysql/weather-service/pom.xml
+++ b/07-build-a-spring-boot-microservice-using-mysql/weather-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/08-build-a-spring-cloud-gateway/README.md
+++ b/08-build-a-spring-cloud-gateway/README.md
@@ -13,10 +13,10 @@ The application that we create in this guide is [available here](gateway/).
 To create our gateway, we will invoke the Spring Initalizr service from the command line:
 
 ```bash
-curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=cloud-gateway,cloud-eureka,cloud-config-client -d baseDir=gateway -d bootVersion=3.1.3 -d javaVersion=17 | tar -xzvf -
+curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=cloud-gateway-reactive,cloud-eureka,cloud-config-client -d baseDir=gateway -d bootVersion=3.3.2 -d javaVersion=17 | tar -xzvf -
 ```
 
-> We use the `Cloud Gateway`, `Eureka Discovery Client` and the `Config Client` components.
+> We use the `Cloud Gateway Reactive`, `Eureka Discovery Client` and the `Config Client` components.
 
 ## Configure the application
 

--- a/08-build-a-spring-cloud-gateway/gateway/pom.xml
+++ b/08-build-a-spring-cloud-gateway/gateway/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/10-blue-green-deployment/weather-service/pom.xml
+++ b/10-blue-green-deployment/weather-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/12-making-microservices-talk-to-each-other/README.md
+++ b/12-making-microservices-talk-to-each-other/README.md
@@ -19,7 +19,7 @@ Note how the code we create in this section is endpoint-agnostic. All we specify
 To create our microservice, we will invoke the Spring Initializr service from the command line:
 
 ```bash
-curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=cloud-feign,web,cloud-eureka,cloud-config-client -d baseDir=all-cities-weather-service -d bootVersion=3.1.3 -d javaVersion=17 | tar -xzvf -
+curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=cloud-feign,web,cloud-eureka,cloud-config-client -d baseDir=all-cities-weather-service -d bootVersion=3.3.2 -d javaVersion=17 | tar -xzvf -
 ```
 
 ## Add Spring code to call other microservices

--- a/12-making-microservices-talk-to-each-other/all-cities-weather-service/pom.xml
+++ b/12-making-microservices-talk-to-each-other/all-cities-weather-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/13-build-a-spring-ai-microservice-with-azure-openai/ai-weather-service/pom.xml
+++ b/13-build-a-spring-ai-microservice-with-azure-openai/ai-weather-service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.3</version>
+		<version>3.3.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>


### PR DESCRIPTION
#### Summary

This pull request addresses issues related to outdated Spring Boot version and incorrect dependencies in the Spring initializer commands.

#### Changes Made

1. **Update Spring Boot Version:**
   - The commands previously used Spring Boot version `3.1.3`, which is no longer available on [start.spring.io](https://start.spring.io/).
   - Updated the Spring Boot version to `3.3.2`.

   ```bash
   curl https://start.spring.io/starter.tgz -d type=maven-project -d dependencies=web -d baseDir=simple-microservice -d bootVersion=3.3.2 -d javaVersion=17 | tar -xzvf -
   ```

2. **Adjust Dependency for Cloud Gateway:**
   - Changed the dependency from `cloud-gateway` to `cloud-gateway-reactive`.
   - The `cloud-gateway` dependency was incorrectly loading `spring-cloud-starter-gateway-mvc` instead of `spring-cloud-starter-gateway`, causing mismatches in `application.yml` and gateway malfunctions.

   ```xml
   <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-gateway</artifactId>
   </dependency>
   ```

#### Reason for Changes

- **Spring Boot Version Error:**
  Running the command with version `3.1.3` results in a `Bad Request` error due to the version being outside the compatibility range. Below is the error message encountered:

  ```json
  {
      "timestamp":"2024-07-24T07:15:12.386+00:00",
      "status":400,
      "error":"Bad Request",
      "message":"Invalid Spring Boot version '3.1.3', Spring Boot compatibility range is >=3.2.0",
      "path":"/starter.tgz"
  }
  ```

- **Dependency Issue:**
  The incorrect `cloud-gateway` dependency was leading to the inclusion of `spring-cloud-starter-gateway-mvc` instead of `spring-cloud-starter-gateway`, causing configuration issues and non-functional gateway setup.


Please review these changes and let me know if any further adjustments are needed. Thank you!
